### PR TITLE
fix: correct typo in variable name from `defaultOptin` to `defaultOption`

### DIFF
--- a/src/defaultOption.ts
+++ b/src/defaultOption.ts
@@ -1,6 +1,6 @@
-const defaultOptin = {
+const defaultOption = {
   statusCodes: [401],
   shouldRefresh: true,
 };
 
-export default defaultOptin;
+export default defaultOption;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR corrects a typo in the variable name, changing defaultOptin to defaultOption. This change improves clarity and prevents potential issues related to the typo.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #7 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
NONE
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Renamed the constant `defaultOptin` to `defaultOption` for improved clarity and correctness in naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->